### PR TITLE
Fix minor errors that pend running training example

### DIFF
--- a/networks/transformer.py
+++ b/networks/transformer.py
@@ -209,7 +209,7 @@ class ObjectTransformer(nn.Module):
         target_hand = future_hands[:, :, 1:, :]
         target_hand = target_hand.reshape(-1, target_hand.shape[-1])
 
-        pred_hand, traj_loss, traj_kl_loss = self.hand_head(x_hand, target_hand, future_valid, contact=None,
+        pred_hand, traj_loss, traj_kl_loss = self.hand_head(x_hand, target_hand, future_valid, contact_point=None,
                                                             return_pred=True)
 
         r_pred_contact, r_obj_loss, r_obj_kl_loss = self.object_head(memory[:, 0, :], contact_point, future_rhand,

--- a/options/expopts.py
+++ b/options/expopts.py
@@ -10,3 +10,5 @@ def add_exp_opts(parser):
     parser.add_argument("--use_cuda", default=1, type=int, help="use GPU (default: True)")
     parser.add_argument('--ek_version', default="ek55", choices=["ek55", "ek100"], help="epic dataset version")
     parser.add_argument("--traj_only", action="store_true", help="evaluate traj on validation dataset")
+    parser.add_argument("--host_folder", default="./host_folder", help="folder path that places all experiment sessions")
+    parser.add_argument("--exp_id", default="0000", help="folder name for one experiment session")    

--- a/traineval.py
+++ b/traineval.py
@@ -101,7 +101,7 @@ def main(args):
                 modelio.save_checkpoint(
                 {
                     "epoch": epoch + 1,
-                    "network": args.network,
+                    "network": "default",
                     "state_dict": model.state_dict(),
                     "optimizer": optimizer.state_dict(),
                 },


### PR DESCRIPTION
When running `python traineval.py --ek_version=ek100` as suggested in README.md, one will get "TypeError" (fixed in patch-1 below) and "AttributeError" (fixed in patch-2,3 below).